### PR TITLE
[Minor] adding equivalent spacing to bottom of Featured Journeys

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:before_main_wrapper) do %>
   <%= render 'searches/search_box' %>
   <main id="main-content" class="govuk-main-wrapper govuk-!-padding-top-0" role="main">
-    <div class="featured-journeys govuk-!-padding-top-9">
+    <div class="featured-journeys govuk-!-padding-top-9 govuk-!-padding-bottom-9">
       <div class="govuk-width-container">
         <%= render 'shared/flash_messages' %>
         <div class="govuk-grid-row">


### PR DESCRIPTION
 
<img width="200" alt="screenshot 2019-02-10 at 16 37 54" src="https://user-images.githubusercontent.com/4403131/52535739-42098880-2d52-11e9-9905-4b76e910e431.png">

Na homepage chýbal padding na spodku featured journeys a šedé pozadie tak končilo rovno dlaždicami