### PR TITLE
Changes for development environment on windows.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'letter_opener_web'
+  gem 'wdm', '~> 0.1.0' if Gem.win_platform?
 end
 
 group :test do
@@ -77,8 +78,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'show_me_the_cookies'
   gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'webdrivers', '~> 3.0'
   gem 'simplecov'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'letter_opener_web'
-  gem 'wdm', '~> 0.1.0' if Gem.win_platform?
+  gem 'wdm', '~> 0.1.0', platforms: [:mingw, :mswin, :x64_mingw]
 end
 
 group :test do


### PR DESCRIPTION
wdm (windows directory monitor) - it was recommended in log when I started development server

webdrivers instead of chromedriver-helper - chromedriver-helper is no more supported (https://github.com/flavorjones/chromedriver-helper/issues/83) and does not work on win (https://github.com/flavorjones/chromedriver-helper/issues/19). Webdrivers is recommended as substitution.