### PR TITLE
Autocomplete for EU Vote Task

### DIFF
--- a/app/views/apps/ep_vote_app/application_forms/address.html.erb
+++ b/app/views/apps/ep_vote_app/application_forms/address.html.erb
@@ -17,7 +17,7 @@
         <% @application_form.errors[:street].each do |error| %>
           <span class="govuk-error-message"><%= error %></span>
         <% end %>
-        <%= f.text_field :street, class: 'govuk-input govuk-input--width-20' %>
+        <%= f.text_field :street, class: 'govuk-input govuk-input--width-20', 'autocomplete': 'address-line1' %>
       </div>
 
       <div class="govuk-form-group<% if @application_form.errors[:pobox].any? %> govuk-form-group--error<% end %>">
@@ -26,7 +26,7 @@
         <% @application_form.errors[:pobox].each do |error| %>
           <span class="govuk-error-message"><%= error %></span>
         <% end %>
-        <%= f.text_field :pobox, class: 'govuk-input govuk-input--width-5' %>
+        <%= f.text_field :pobox, class: 'govuk-input govuk-input--width-5', 'autocomplete': 'postal-code' %>
       </div>
 
       <div class="govuk-form-group<% if @application_form.errors[:municipality].any? %> govuk-form-group--error<% end %>">

--- a/app/views/apps/ep_vote_app/application_forms/delivery_address.html.erb
+++ b/app/views/apps/ep_vote_app/application_forms/delivery_address.html.erb
@@ -35,7 +35,7 @@
               <% @application_form.errors[:delivery_street].each do |error| %>
                 <span class="govuk-error-message"><%= error %></span>
               <% end %>
-              <%= f.text_field :delivery_street, class: 'govuk-input govuk-input--width-20' %>
+              <%= f.text_field :delivery_street, class: 'govuk-input govuk-input--width-20', 'autocomplete': 'address-line1' %>
             </div>
 
             <div class="govuk-form-group<% if @application_form.errors[:delivery_pobox].any? %> govuk-form-group--error<% end %>">
@@ -44,7 +44,7 @@
               <% @application_form.errors[:delivery_pobox].each do |error| %>
                 <span class="govuk-error-message"><%= error %></span>
               <% end %>
-              <%= f.text_field :delivery_pobox, class: 'govuk-input govuk-input--width-5' %>
+              <%= f.text_field :delivery_pobox, class: 'govuk-input govuk-input--width-5', 'autocomplete': 'postal-code' %>
             </div>
 
             <div class="govuk-form-group<% if @application_form.errors[:delivery_municipality].any? %> govuk-form-group--error<% end %>">
@@ -52,7 +52,7 @@
               <% @application_form.errors[:delivery_municipality].each do |error| %>
                 <span class="govuk-error-message"><%= error %></span>
               <% end %>
-              <%= f.text_field :delivery_municipality, class: 'govuk-input govuk-input--width-10' %>
+              <%= f.text_field :delivery_municipality, class: 'govuk-input govuk-input--width-10', 'autocomplete': 'address-level2' %>
             </div>
 
             <div class="govuk-form-group<% if @application_form.errors[:delivery_country].any? %> govuk-form-group--error<% end %>">
@@ -60,7 +60,7 @@
               <% @application_form.errors[:delivery_country].each do |error| %>
                 <span class="govuk-error-message"><%= error %></span>
               <% end %>
-              <%= f.text_field :delivery_country, class: 'govuk-input govuk-input--width-10' %>
+              <%= f.text_field :delivery_country, class: 'govuk-input govuk-input--width-10', 'autocomplete': 'country-name' %>
             </div>
           </div>
         </div>

--- a/app/views/apps/ep_vote_app/application_forms/identity.html.erb
+++ b/app/views/apps/ep_vote_app/application_forms/identity.html.erb
@@ -14,7 +14,7 @@
         <% @application_form.errors[:full_name].each do |error| %>
           <span class="govuk-error-message"><%= error %></span>
         <% end %>
-        <%= f.text_field :full_name, class: 'govuk-input govuk-input--width-20' %>
+        <%= f.text_field :full_name, class: 'govuk-input govuk-input--width-20', 'autocomplete': 'name' %>
       </div>
 
       <div class="govuk-form-group<% if @application_form.errors[:pin].any? %> govuk-form-group--error<% end %>">


### PR DESCRIPTION
Adding some autocomplete/auto-fill properties

- Municipality was drop-down object thus could not autocomplete.
- Personal ID and Nationality are out of scope of autocomplete.

Even with this being a partial solution, my biggest problem was to enter address with correct diacritic on my US English only device, this solves that for me.