### PR TITLE
Buttony pomocou border namiesto padding

### DIFF
--- a/app/assets/stylesheets/mailer.scss
+++ b/app/assets/stylesheets/mailer.scss
@@ -189,7 +189,7 @@ a {
   width: auto;
 }
 
-.btn .btn-td {
+.btn .btn-inner {
   background-color: $green;
   border: 2px solid rgba(0,0,0,0);
   border-radius: 3px;
@@ -199,22 +199,19 @@ a {
   font-size: $font_size;
   font-weight: 700;
   margin: 0;
-  padding: 12px 15px;
+  padding: 0;
   text-decoration: none;
+  border: 12px solid $green;
+  border-left-width: 20px;
+  border-right-width: 20px;
+  display: inline-block;
 
   &:hover,
   &:active,
   &:focus {
+    border-color: darken($green, 10%) !important;
     background-color: darken($green, 10%) !important;
-  }
-
-  * {
-    color: white;
-    text-decoration: none;
-
-    &:hover {
-      color: white !important;
-    }
+    color: white !important;
   }
 }
 
@@ -285,10 +282,6 @@ a {
 
   .body-inner .btn {
     width: 100% !important;
-  }
-
-  .btn td {
-    font-size: $font-size - 1px !important;
   }
 
   p,

--- a/app/views/components/_email_btn.html.erb
+++ b/app/views/components/_email_btn.html.erb
@@ -1,8 +1,10 @@
 <table border="0" cellpadding="0" cellspacing="0" class="btn">
   <tbody>
     <tr>
-      <td class="btn-td">
-        <%= yield %>
+      <td>
+        <%= link_to url, class: "btn-inner" do %>
+          <%= yield %>
+        <% end %>
       </td>
     </tr>
     <tr>

--- a/app/views/notification_subscription_mailer/confirmation_email.html.erb
+++ b/app/views/notification_subscription_mailer/confirmation_email.html.erb
@@ -1,8 +1,8 @@
 <div class="center">
   <p>Pre potvrdenie zasielania notifikácii na stránke Návody.Digital kliknite na nasledujúci odkaz.</p>
 
-  <%= render "components/email_btn" do %>
-    <%= link_to 'Potvrdzujem zasielanie notifikácii', confirm_notification_subscription_group_url(@token) %>
+  <%= render "components/email_btn", url: confirm_notification_subscription_group_url(@token) do %>
+    Potvrdzujem zasielanie notifikácii
   <% end %>
 
   <p class="small grey">Tento odkaz je platný 24 hodín. Ak ste si tento email nevyžiadali Vy, môžete ho pokojne ignorovať.</p>


### PR DESCRIPTION
Vsimol som si maly problem, iba text v buttonoch je klikatelny (namiesto celeho buttonu):

<table>
<tr>
<th>Predtym</th>
<th>Teraz</th>
</tr>
<tr>
<td>

![btn prev](https://user-images.githubusercontent.com/1857751/58441473-51110e00-8097-11e9-9b95-aeb3474e53d8.gif)

</td>
<td>

![btn now](https://user-images.githubusercontent.com/1857751/58441472-51110e00-8097-11e9-9012-d782dc47c855.gif)

</td>
</tr>
</table>

Najvacsi problem je ze vacsina novsich outlook verzii nepozna paddings na nicom okrem tabulky. (neviem koho napadlo ako dobry napad pozuit rendering engine z wordu :/)

Predtym bol padding na td, avsak to znamenalo ze sa dalo klikat len na link.
Fixol som to presunutim stylov na anchor a pouzitim borderu namiesto paddingu ktory funguje aj v outlooku. (jednoducho nestnut celu tabulky do linku nejde)
Button stale musi byt v tabulke kvolu spacingu, pretoze outlook zarata velkost buttonu do marginu a buto vyzerat akoby tam nebol ziadny spacing. (je to bordel proste :))

Zopar screenshotov:

### gmail_com_chrome
![gmail_com_chrome](https://user-images.githubusercontent.com/1857751/58441504-6f770980-8097-11e9-82e5-85fb622f08c4.png)

### iPhone6
![iPhone6](https://user-images.githubusercontent.com/1857751/58441675-b3b6d980-8098-11e9-8e81-f8f8fe116c2a.png)

### MacOSX_mail12
![MacOSX_mail12](https://user-images.githubusercontent.com/1857751/58441699-df39c400-8098-11e9-8295-bd930348682c.png)

### win_outlook2016_accessibility
![win_outlook2016_accessibility](https://user-images.githubusercontent.com/1857751/58441700-e06af100-8098-11e9-8126-6a48640b93aa.png)

