### PR TITLE
Add apps as standalone application records.

### DIFF
--- a/app/controllers/admin/apps_controller.rb
+++ b/app/controllers/admin/apps_controller.rb
@@ -1,0 +1,61 @@
+class Admin::AppsController < Admin::AdminController
+  before_action :set_app, only: [:edit, :update, :destroy]
+
+  # GET /apps
+  def index
+    @apps = App.all
+  end
+
+  # GET /apps/new
+  def new
+    @app = App.new
+  end
+
+  # GET /apps/1/edit
+  def edit
+  end
+
+  # POST /apps
+  def create
+    @app = App.new(app_params)
+
+    if @app.save
+      redirect_to admin_apps_url, notice: 'App was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /apps/1
+  def update
+    if @app.update(app_params)
+      redirect_to admin_apps_url, notice: 'App was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /apps/1
+  def destroy
+    @app.destroy
+    redirect_to admin_apps_url, notice: 'App was successfully destroyed.'
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_app
+    @app = App.find_by(slug: params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def app_params
+    params.require(:app).permit(
+      :title,
+      :image_name,
+      :published_status,
+      :slug,
+      :description
+    )
+  end
+end

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -1,0 +1,34 @@
+class Admin::DocumentsController < Admin::AdminController
+  before_action :set_document, only: [:show, :edit, :update]
+
+  # GET /admin/documents
+  def index
+    @documents = PgSearch::Document.where(searchable_type: ['Journey', 'App']).includes(:searchable).select(&:searchable)
+  end
+
+  # GET /admin/documents/1/edit
+  def edit
+  end
+
+  # PATCH/PUT /admin/journeys/1
+  def update
+    if @document.update(document_params)
+      redirect_to admin_documents_url, notice: 'Journey was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_document
+    @document = PgSearch::Document.find(params[:id])
+  end
+
+  def document_params
+    params.require(:pg_search_document).permit(
+      :slug,
+      :position,
+    )
+  end
+end

--- a/app/controllers/admin/journeys_controller.rb
+++ b/app/controllers/admin/journeys_controller.rb
@@ -67,7 +67,6 @@ class Admin::JourneysController < Admin::AdminController
         :published_status,
         :slug,
         :description,
-        :position
     )
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
     @metadata.og.description = 'Interaktívne návody, ako vybaviť úradné záležitosti elektronicky.'
 
     @faqs = Page.faq.all # TODO: fetch top FAQs here
-    @journeys = Journey.published
+    @documents = PgSearch::Document.featured_on_front_page.includes(:searchable).map(&:searchable).compact # we do not have FK constraints here, compact eliminates any possible documents hanging without searchable counterpart, which was deleted
   end
 
   def show

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,7 +5,7 @@ class SearchesController < ApplicationController
     @q = params[:q]
     @analyzed_q = Transliterator.transliterate(@q)
     @searches = PgSearch::Document
-                  .where(searchable_type: %w(Page Journey))
+                  .where(searchable_type: %w(Page Journey App))
                   .search(@analyzed_q)
                   .page(params[:page])
                   .per(10)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,12 @@ module ApplicationHelper
     [title, category, 'Návody.Digital'].compact.join(' | ')
   end
 
+  def decide_searchable_path(searchable)
+    return app_path(searchable.slug) if searchable.is_a? App
+
+    journey_path(searchable.slug)
+  end
+
   def build_step_page_title(step)
     build_page_title(step.custom_title.presence || step.title, step.journey.custom_title.presence || step.journey.title)
   end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -1,0 +1,42 @@
+class App < ApplicationRecord
+  include Enums
+  include Searchable
+
+  scope :published, -> { where(published_status: 'PUBLISHED')}
+
+  has_many :search_documents, :class_name => 'PgSearch::Document', as: :searchable
+
+  enumerates :published_status, with: %w{DRAFT PUBLISHED}
+
+  validates :title, presence: true
+  validates :slug, presence: true, uniqueness: true
+
+  multisearchable against: %i(description_search),
+    if: :published?,
+    additional_attributes: -> (app) {
+      { title: app.title_search,
+        published: app.published?}
+    }
+
+  def published?
+    published_status == 'PUBLISHED'
+  end
+
+  def to_param
+    slug
+  end
+
+  def title_search
+    join_search([to_search_str(title)])
+  end
+
+  def description_search
+    join_search([html_to_search_str(description)])
+  end
+
+  private
+
+  def join_search(arr)
+    arr.delete_if{ |i| i.blank? }.join(' ')
+  end
+end

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -4,13 +4,13 @@ class Journey < ApplicationRecord
 
   before_save :update_steps_search
 
-  default_scope { order(position: :asc) }
-
   scope :published, -> { where(published_status: 'PUBLISHED')}
 
   has_many :steps, dependent: :destroy
   has_many :tasks, through: :steps
   has_many :user_journeys
+
+  has_many :search_documents, :class_name => 'PgSearch::Document', as: :searchable
 
   enumerates :published_status, with: %w{DRAFT PUBLISHED}
 
@@ -23,7 +23,8 @@ class Journey < ApplicationRecord
                   if: :published?,
                   additional_attributes: -> (journey) {
                     { title: journey.title_search,
-                      keywords: journey.keywords_search }
+                      keywords: journey.keywords_search,
+                      published: journey.published?}
                   }
 
   def published?

--- a/app/models/pg_search/document.rb
+++ b/app/models/pg_search/document.rb
@@ -3,6 +3,10 @@ class PgSearch::Document < ::ActiveRecord::Base
   self.table_name = 'pg_search_documents'
   belongs_to :searchable, polymorphic: true
 
+  default_scope { order(position: :asc) }
+
+  scope :featured_on_front_page, -> { where(searchable_type: ['Journey', 'App']).where(published: true)}
+
   pg_search_scope :search, against: {
     keywords: 'A',
     title: 'A',

--- a/app/views/admin/apps/_form.html.erb
+++ b/app/views/admin/apps/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(model: [:admin, app], local: true, builder: AdminFormBuilder) do |form| %>
+  <% if app.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(app.errors.count, "error") %> prohibited this app from being saved</h2>
+    </div>
+  <% end %>
+
+  <%= form.text_field :title %>
+  <%= form.text_field :slug %>
+  <%= form.select :published_status, App.defined_enums['published_status'] %>
+  <%= form.select :image_name, Dir.glob("app/assets/images/journeys/*").map { |path| File.basename(path) } %>
+  <%= form.text_area :description, size: "60x12" %>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/apps/edit.html.erb
+++ b/app/views/admin/apps/edit.html.erb
@@ -1,0 +1,3 @@
+<%= render 'breadcrumbs', crumbs: [['Apps', admin_apps_url], [@app.title, '#']], current: 'Edit' %>
+
+<%= render 'form', app: @app %>

--- a/app/views/admin/apps/index.html.erb
+++ b/app/views/admin/apps/index.html.erb
@@ -1,0 +1,26 @@
+<p id="notice"><%= notice %></p>
+
+<%= render 'breadcrumbs', crumbs: [], current: 'Apps' %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Title</th>
+      <th class="govuk-table__header" scope="col"></th>
+      <th class="govuk-table__header" scope="col" colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @apps.each do |app| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= link_to app.title, app_path(app.slug) %> <%= "(#{app.published_status})" if app.published_status != 'PUBLISHED' %></td>
+        <td class="govuk-table__cell"><%= link_to 'Edit', edit_admin_app_path(app) %></td>
+        <td class="govuk-table__cell"><%= link_to 'Destroy', [:admin, app], method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New App', new_admin_app_path, class: 'govuk-button' %>

--- a/app/views/admin/apps/new.html.erb
+++ b/app/views/admin/apps/new.html.erb
@@ -1,0 +1,5 @@
+<%= render 'breadcrumbs', crumbs: [['Apps', admin_apps_url]], current: 'New' %>
+
+<%= render 'form', app: @app %>
+
+<%= link_to 'Back', admin_apps_path %>

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_for(document, url: admin_document_path(document), builder: AdminFormBuilder) do |form| %>
+  <% if document.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(document.errors.count, "error") %> prohibited this document from being saved</h2>
+    </div>
+  <% end %>
+
+  <%= form.text_field :position %>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/documents/edit.html.erb
+++ b/app/views/admin/documents/edit.html.erb
@@ -1,0 +1,3 @@
+<%= render 'breadcrumbs', crumbs: [['Documents', admin_documents_url], [@document.searchable.title, '#']], current: 'Edit' %>
+
+<%= render 'form', document: @document %>

--- a/app/views/admin/documents/index.html.erb
+++ b/app/views/admin/documents/index.html.erb
@@ -1,0 +1,25 @@
+<p id="notice"><%= notice %></p>
+
+<%= render 'breadcrumbs', crumbs: [], current: 'Documents' %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Position</th>
+      <th class="govuk-table__header" scope="col">Slug</th>
+      <th class="govuk-table__header" scope="col">Type</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @documents.each do |document| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= document.position %></td>
+        <td class="govuk-table__cell"><%= link_to document.searchable.slug, decide_searchable_path(document.searchable) %></td>
+        <td class="govuk-table__cell"><%= document.searchable_type %></td>
+        <td class="govuk-table__cell"><%= link_to 'Edit', edit_admin_document_path(document) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>

--- a/app/views/admin/documents/new.html.erb
+++ b/app/views/admin/documents/new.html.erb
@@ -1,0 +1,5 @@
+<%= render 'breadcrumbs', crumbs: [['Journeys', admin_journeys_url]], current: 'New' %>
+
+<%= render 'form', journey: @journey %>
+
+<%= link_to 'Back', admin_journeys_path %>

--- a/app/views/admin/journeys/_form.html.erb
+++ b/app/views/admin/journeys/_form.html.erb
@@ -11,7 +11,6 @@
   <%= form.text_field :keywords %>
   <%= form.select :published_status, Journey.defined_enums['published_status'] %>
   <%= form.select :image_name, Dir.glob("app/assets/images/journeys/*").map { |path| File.basename(path) } %>
-  <%= form.number_field :position %>
   <%= form.number_field :featured_position %>
   <%= form.text_area :description, size: "60x12" %>
 

--- a/app/views/admin/journeys/index.html.erb
+++ b/app/views/admin/journeys/index.html.erb
@@ -5,7 +5,6 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Pos</th>
       <th class="govuk-table__header" scope="col">Featured Pos</th>
       <th class="govuk-table__header" scope="col">Title</th>
       <th class="govuk-table__header" scope="col"></th>
@@ -15,7 +14,6 @@
   <tbody class="govuk-table__body">
     <% @journeys.each do |journey| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= journey.position %></td>
         <td class="govuk-table__cell"><%= journey.featured_position %></td>
         <td class="govuk-table__cell"><%= link_to journey.title, journey %> <%= "(#{journey.published_status})" if journey.published_status != 'PUBLISHED' %></td>
         <td class="govuk-table__cell"><%= link_to "Steps (#{journey.steps.count})", admin_journey_steps_path(journey) %></td>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -36,11 +36,17 @@
         <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
         <nav>
           <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+            <li class="govuk-header__navigation-item govuk-header__navigation-item">
+              <%= link_to 'Featured on front page', admin_documents_path, class: 'govuk-header__link' %>
+            </li>
             <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
               <%= link_to 'Pages', admin_pages_path, class: 'govuk-header__link' %>
             </li>
             <li class="govuk-header__navigation-item">
               <%= link_to 'Journeys', admin_journeys_path, class: 'govuk-header__link' %>
+            </li>
+            <li class="govuk-header__navigation-item">
+              <%= link_to 'Apps', admin_apps_path, class: 'govuk-header__link' %>
             </li>
             <li class="govuk-header__navigation-item">
               <%= link_to 'UserJourneys', admin_user_journeys_path, class: 'govuk-header__link' %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -8,13 +8,13 @@
         <%= render 'shared/flash_messages' %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-l">Najpoužívanejšie návody</h2>
+            <h2 class="govuk-heading-l">Najpoužívanejšie návody a aplikácie</h2>
             <div class="sdn-tiles">
-              <% @journeys.each do |journey| %>
-                <%= link_to journey_path(journey.slug), class: 'sdn-tiles__item sdn-tile' do %>
-                  <%= image_tag "journeys/#{journey.image_name.presence || "placeholder.png"}", class: 'sdn-tile__image' %>
+              <% @documents.each do |searchable| %>
+                <%= link_to decide_searchable_path(searchable), class: 'sdn-tiles__item sdn-tile' do %>
+                  <%= image_tag "journeys/#{searchable.image_name.presence || "placeholder.png"}", class: 'sdn-tile__image' %>
                   <span class="sdn-tile__content sdn-tile-content-text-block">
-                    <span class="sdn-tile-content-text-block__item"><%= journey.title %></span>
+                    <span class="sdn-tile-content-text-block__item"><%= searchable.title %></span>
                   </span>
                 <% end %>
               <% end %>

--- a/app/views/searches/_app.html.erb
+++ b/app/views/searches/_app.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-!-margin-top-5">
+  <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
+    <%= link_to app.title, app_path(app.slug), class: 'govuk-link' %>
+  </h3>
+  <p class="govuk-body-s">
+    <%= searched_text(app.description, query) %>
+  </p>
+</div>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -18,6 +18,8 @@
               <%= render partial: 'journey', locals: { journey: search.searchable, query: @q, analyzed_query: @analyzed_q } %>
             <% elsif search.searchable_type == 'Page' %>
               <%= render partial: 'page', locals: { page: search.searchable, query: @q } %>
+            <% elsif search.searchable_type == 'App' %>
+              <%= render partial: 'app', locals: { app: search.searchable, query: @q } %>
             <% end %>
           <% end %>
           <%= render partial: 'pagination', locals: { searches: @searches } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: redirect('admin/pages')
 
+    resources :documents, only: [:index, :edit, :update]
+    resources :apps, except: [:show]
     resources :pages, except: [:show]
     resources :journeys, except: [:show] do
       resources :steps, except: [:show] do

--- a/db/migrate/20190608130459_create_apps.rb
+++ b/db/migrate/20190608130459_create_apps.rb
@@ -1,0 +1,15 @@
+class CreateApps < ActiveRecord::Migration[5.2]
+  def change
+    create_table :apps do |t|
+      t.text :title, null: false
+      t.text :slug, null: false, unique: true
+      t.text :image_name, null: false
+
+      t.text :published_status, null: false
+
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190608135807_add_position_to_pg_search_document.rb
+++ b/db/migrate/20190608135807_add_position_to_pg_search_document.rb
@@ -1,0 +1,14 @@
+class AddPositionToPgSearchDocument < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pg_search_documents, :position, :integer, default: 0
+    add_column :pg_search_documents, :published, :boolean, default: false
+
+    Journey.includes(:search_documents).find_each do |journey|
+      journey.search_documents.each do |document|
+        document.update_attributes({position: journey.position, published: journey.published?})
+      end
+    end
+
+    remove_column :journeys, :position
+  end
+end

--- a/spec/factories/journey.rb
+++ b/spec/factories/journey.rb
@@ -7,6 +7,5 @@ FactoryBot.define do
     published_status { 'PUBLISHED' }
     slug { title.parameterize }
     description { Faker::Lorem.paragraph(5) }
-    sequence(:position) { |n| n }
   end
 end


### PR DESCRIPTION
We want the same kind of interactions as we have with journeys also with apps.

This commit

- Introduces new resource (App). It is searchable through its link to PgSearch::Document.
- Removes position from Journey and puts it to PgSearch::Document
- Changes behavior of title page - it shows journeys & apps types of documents, according to document positions
- Adds Documents section to admin (so that we can adjust positions)
- Adds Apps section to admin