### PR TITLE
Redirect EU application

### DIFF
--- a/app/controllers/apps/ep_vote_app/application_forms_controller.rb
+++ b/app/controllers/apps/ep_vote_app/application_forms_controller.rb
@@ -1,5 +1,5 @@
 class Apps::EpVoteApp::ApplicationFormsController < ApplicationController
-  before_action :set_metadata
+  before_action :set_metadata, :check_inactive_eu_application
 
   def show
     @metadata.og.title = 'Voľby do Európskeho parlamentu'
@@ -37,5 +37,11 @@ class Apps::EpVoteApp::ApplicationFormsController < ApplicationController
   def set_metadata
     @metadata.og.image = 'og-ep-vote-app.png'
     @metadata.og.description = 'Zistite kde a ako môžete voliť. Vybavte si hlasovací preukaz.'
+  end
+
+  def check_inactive_eu_application
+    return if Apps::EpVoteApp::ApplicationForm.active?
+    return redirect_to apps_ep_vote_app_application_forms_path if action_name != "show"
+    render 'inactive'
   end
 end

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -1,4 +1,6 @@
 class JourneysController < ApplicationController
+  before_action :redirect_inactive_eu_application
+
   def show
     @journey = Journey.published.find_by!(slug: params[:id])
     @next_step = @journey.steps.order(:position).first
@@ -6,5 +8,10 @@ class JourneysController < ApplicationController
     load_newest_user_journey(current_user, @journey)
 
     @metadata.og.image = "journeys/#{@journey.image_name.presence || "placeholder.png" }"
+  end
+
+  private def redirect_inactive_eu_application
+    return if Apps::EpVoteApp::ApplicationForm.active?
+    redirect_to apps_ep_vote_app_application_forms_path if params[:id] == "volby-do-eu-parlamentu"
   end
 end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -1,4 +1,6 @@
 class StepsController < ApplicationController
+  before_action :redirect_inactive_eu_application, only: :show
+
   def show
     @journey = Journey.find_by!(slug: params[:journey_id])
     @steps = @journey.steps
@@ -36,5 +38,10 @@ class StepsController < ApplicationController
     step = journey.steps.find_by!(slug: params[:id])
 
     redirect_to step.app_url
+  end
+
+  private def redirect_inactive_eu_application
+    return if Apps::EpVoteApp::ApplicationForm.active?
+    redirect_to apps_ep_vote_app_application_forms_path if params[:journey_id] == "volby-do-eu-parlamentu"
   end
 end

--- a/app/models/apps/ep_vote_app/application_form.rb
+++ b/app/models/apps/ep_vote_app/application_form.rb
@@ -38,6 +38,10 @@ module Apps
       validates_presence_of :delivery_municipality, message: 'Zadajte obec', on: :delivery_address, unless: ->(f) { f.same_delivery_address? }
       validates_presence_of :delivery_country, message: 'Zadajte štát', on: :delivery_address, unless: ->(f) { f.same_delivery_address? }
 
+      def self.active?
+        false
+      end
+
       def nationality
         return @nationality unless @nationality.blank?
         return 'Slovenská republika' if sk_citizen == 'yes'
@@ -64,7 +68,7 @@ Dobrý deň,
 týmto žiadam o vydanie hlasovacieho preukazu pre voľby do Európskeho parlamentu v roku 2019.
 
 Moje identifikačné údaje sú:
-          
+
 Meno: #{full_name}
 Rodné číslo: #{pin}
 Trvalý pobyt: #{street}, #{pobox} #{municipality}

--- a/app/views/apps/ep_vote_app/application_forms/inactive.html.erb
+++ b/app/views/apps/ep_vote_app/application_forms/inactive.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :title, build_page_title('Voľby do Európskeho parlamentu už skončili') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-xl">Voľby do Európskeho parlamentu už skončili.</h2>
+    <h3 class="govuk-heading-l">Aktivujte si upozornenia na email, aby ste na nič nezabudli.</h3>
+    <%= render_notification_subscription_component ['VoteSubscription', 'NewsletterSubscription'] %>
+  </div>
+</div>

--- a/spec/features/apps/ep_vote_app_spec.rb
+++ b/spec/features/apps/ep_vote_app_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
+require_relative '../../../app/models/apps/ep_vote_app/application_form'
 
 RSpec.feature "EP vote app", type: :feature do
+  before do
+    allow(Apps::EpVoteApp::ApplicationForm).to receive(:active?).and_return(true)
+  end
+
   scenario 'As a citizen I want to request voting permit via post' do
     travel_to Date.new(2019, 5, 3)
 
@@ -164,5 +169,13 @@ RSpec.feature "EP vote app", type: :feature do
     click_button 'Pokračovať'
 
     expect(page).to have_content('Hlasovanie v zahraničí')
+  end
+
+  scenario 'Expired application' do
+    allow(Apps::EpVoteApp::ApplicationForm).to receive(:active?).and_return(false)
+    visit apps_ep_vote_app_application_forms_path
+
+    expect(page).to have_content('Voľby do Európskeho parlamentu už skončili.')
+    expect(page).to have_content('Chcem dostávať upozornenia k voľbám')
   end
 end

--- a/spec/features/notification_subscriptions_spec.rb
+++ b/spec/features/notification_subscriptions_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require_relative '../../app/models/apps/ep_vote_app/application_form'
 
 RSpec.feature "Notification subscriptions", type: :feature do
   let!(:user) {create(:user, email: 'someone@example.com')}
@@ -16,10 +17,11 @@ RSpec.feature "Notification subscriptions", type: :feature do
     visit link_in_last_email
   end
 
-  before(:each) do
+  before do
     # https://stackoverflow.com/questions/598933/how-do-i-change-the-default-www-example-com-domain-for-testing-in-rails
     default_url_options[:host] = "localhost:3000"
     Capybara.default_host = "http://localhost:3000"
+    allow(Apps::EpVoteApp::ApplicationForm).to receive(:active?).and_return(true)
   end
 
   scenario 'As a visitor I want to subscribe to various notifications' do

--- a/spec/requests/ep_vote_app_spec.rb
+++ b/spec/requests/ep_vote_app_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require_relative "../../app/models/apps/ep_vote_app/application_form"
+
+describe "EU vote application redirects", type: :request do
+  before do
+    allow(Apps::EpVoteApp::ApplicationForm).to receive(:active?).and_return(false)
+  end
+
+  it "should redirect inactive journey to vote application index" do
+    get "/zivotne-situacie/volby-do-eu-parlamentu"
+    expect(response).to redirect_to(apps_ep_vote_app_application_forms_path)
+  end
+
+  it "should redirect inactive journey step to vote application index" do
+    get "/zivotne-situacie/volby-do-eu-parlamentu/krok/zistit-kde-a-ako-volit"
+    expect(response).to redirect_to(apps_ep_vote_app_application_forms_path)
+  end
+
+  it "should redirect eu application members to vote application index" do
+    get eu_apps_ep_vote_app_application_forms_path
+    expect(response).to redirect_to(apps_ep_vote_app_application_forms_path)
+  end
+end


### PR DESCRIPTION
fixes https://github.com/slovensko-digital/navody.digital/issues/233

Ahoj, neviem ci nieco take mate namysli, ale ak ano tak pridam testy. (+ fixnem vsetko co failuje momentalne)

`/aplikacie/volby-do-europskeho-parlamentu/` je jedina url ktora reneruje, vsetko ostatne redirectuje nanu. Vyzera takto:

<img width="740" alt="Screen Shot 2019-07-09 at 22 59 26" src="https://user-images.githubusercontent.com/1857751/60944732-8025bc80-a29e-11e9-984d-f22603831c88.png">
 
EU volby journey potom mozte unpublishnut.