### PR TITLE
ignore length of document to prevent blank journeys ranked as first

### DIFF
--- a/app/models/pg_search/document.rb
+++ b/app/models/pg_search/document.rb
@@ -22,7 +22,7 @@ class PgSearch::Document < ::ActiveRecord::Base
     tsearch: {
       any_word: true,
       prefix: false,
-      normalization: 1,
+      normalization: 0,
     },
   }
 end

--- a/spec/models/pg_search/document_spec.rb
+++ b/spec/models/pg_search/document_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe PgSearch::Document, type: :model do
     end
 
     context 'doc length normalization' do
-      it 'penalizes by document lengths' do
+      it 'will not penalize by document lengths' do
         page2 = create(:page, is_faq: true, title: (query+' ') * 20)
         page1 = create(:page, is_faq: true, title: (query+' ') * 5)
-        expect(subject.collect(&:searchable)).to eq [page1, page2]
+        expect(subject.collect(&:searchable)).to eq [page2, page1]
       end
     end
   end


### PR DESCRIPTION
#268 

Zo zvolenych moznosti rankingu pomohlo nastavit tam default (ignorovat dlzku dokumentu). Treba ale overit, ci toto riesenie nepokazi vseobecne spravnost searchu, no mam pocit, ze pri journeys by ta dlzka nemusela zohravat velku rolu.

Zoznam vsetkych moznosti:
https://github.com/Casecommons/pg_search
```
0 (the default) ignores the document length
1 divides the rank by 1 + the logarithm of the document length
2 divides the rank by the document length
4 divides the rank by the mean harmonic distance between extents
8 divides the rank by the number of unique words in document
16 divides the rank by 1 + the logarithm of the number of unique words in document
32 divides the rank by itself + 1
```