### PR TITLE
No logs on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,15 +79,8 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  # For security reasons we don't keep any logs
+  config.logger = Logger.new('/dev/null')
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
For security reasons and better trustworthiness of the portal  don't store any logs in production (as logs they may contain date of births etc)

e.g. http://www.volby.digital/  I'm providing sensitive data like Date of birth => bit paranoid person will resist to use it 

Why not just use STDOUT ? ...Standard output is by default just output on screen. But problem is that  owner of server may redirect STDOUT value to file persistence => log sensitive data to file 

I would recommend just don't log anything by redirecting log output to [/dev/null](https://en.wikipedia.org/wiki/Null_device) for better transparency of intentions of the portal


If this is too radical I've created alternative PR - [enforce STDOUT logs only on production](https://github.com/slovensko-digital/navody.digital/pull/334)    

pls pick one and close other