### PR TITLE
enforce STDOUT logs only on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,11 +83,9 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  logger           = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger    = ActiveSupport::TaggedLogging.new(logger)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION

This is alternative PR to the original [PR - No logs on production](https://github.com/slovensko-digital/navody.digital/pull/333)  

I prefer  the No logs on production PR solution but if it's too radical at least remove the ENV variable option and log only to STDOUT logging in production .... for transparency of intention of the portal