### PR TITLE
Add docker development environment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.circleci
+Dockerfile
+.git/
+.gitignore
+node_modules/
+vendor/bundle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ruby:2.6.6-buster
+
+ARG user=sk
+
+RUN useradd -m -s /bin/bash ${user} && \
+  # Add node repo
+  curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  echo "deb https://deb.nodesource.com/node_12.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  # Add postgresql repo
+  curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
+  # Add yarn repo
+  curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+  # Install node
+  nodejs \
+  # Install pg gem deps
+  libpq-dev \
+  postgresql-client-12 \
+  # Install yarn
+  yarn && \
+  rm -rf /var/lib/apt/lists/* && \
+  # Install bundler version to match Gemfile.lock
+  gem install bundler:2.1.4 && \
+  # Create directories for docker volumes
+  mkdir -p /app/vendor/bundle /app/node_modules && \
+  chown ${user}: /app/vendor/bundle /app/node_modules
+
+WORKDIR /app
+USER ${user}
+ENV RAILS_ENV=development
+RUN bundle config set deployment true

--- a/README.md
+++ b/README.md
@@ -11,18 +11,36 @@ Master ide automaticky na https://staging.navody.digital/
 ### Setup
 
 #### OSX (homebrew)
- - `brew install postgresql`
- - `brew services start postgresql`
- - `bin/setup`
- - `bin/rails s`
- 
+
+- `brew install postgresql`
+- `brew services start postgresql`
+- `bin/setup`
+- `bin/rails s`
+
+#### Docker
+
+- Download & install:
+  - [git](https://git-scm.com/downloads)
+  - [Docker CE](https://docs.docker.com/install/)
+  - [Docker Compose](https://docs.docker.com/compose/install/) 
+- Clone the git repo: `git clone git@github.com:slovensko-digital/navody.digital.git`
+- Move into the newly cloned directory: `cd navody.digital`
+- Build docker image and start the development environment: `docker-compose up --build -d`. Note: this needs to be run only on first setup and then only on `Dockerfile`/`docker-compose.yml` change
+- Setup the environment:
+  - Attach to the `app` container: `docker-compose exec app bash`
+  - (Optional) Install node modules: `yarn`
+  - Run the setup command (installs gems, prepares DB, ..): `bin/setup`
+  - Start the rails server: `bin/rails s`
+- To stop the environment, run: `docker-compose stop`
+- To start it again, run: `docker-compose start`
+
 #### Test Enviroment
 
 Na spustenie system testov:
 
- - `bin/rails db:create`
- - `bin/rails db:setup`
- - `bin/rake`
+- `bin/rails db:create`
+- `bin/rails db:setup`
+- `bin/rake`
 
 ### Neprogramátorské úlohy
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.7"
+services:
+  db:
+    image: postgres:12
+    environment:
+      - POSTGRES_DB=${DATABASE_NAME:-navody_slovensko_digital_development}
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    expose:
+      - 5432/tcp
+    networks:
+      - navody
+    ports:
+      - 5432:5432
+    restart: unless-stopped
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+  app:
+    image: navody
+    build: .
+    command: "tail -f /dev/null"
+    depends_on:
+      - db
+    environment:
+      - RAILS_ENV=development
+      - DATABASE_URL=postgresql://postgres@db/${DATABASE_NAME:-navody_slovensko_digital_development}
+    networks:
+      - navody
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    volumes:
+      - ./:/app
+      - bundler:/app/vendor/bundle
+      - node_modules:/app/node_modules
+networks:
+  navody:
+    driver: bridge
+volumes:
+  bundler:
+    driver: local
+  node_modules:
+    driver: local
+  pg_data:
+    driver: local


### PR DESCRIPTION
# PR info
PR pridava podporu pre lokalny development environment pomocou dockeru.  Toto ma nasledovne vlastnosti:
* vyazduje len docker & docker-compose a netreba riesit ziadne konflikty uz nainstalovanych ruby/rails/postgres na lokajnej masine
* pouziva verzie, ktore su pouzivane inde v projekte (postgres 12, ruby 2.6.6, bundler 2.1.4,...).

Motivacia: 
* chcel som si rozbehat navody.digital na laptope, nech sa pozriem na nejake bugy, no kedze robim na viacerych projektoch, nikdy nic neinstalujem lokalne a preto mi aktualny setup nevyhovoval
* moze to byt osozne pre novych contributorov/hackatony na rychle zacatie s vyvojom.


## Zmeny:
* Add Dockerfile, docker-compose.yml, .dockerignore
* Update README 

## Problemy:
* `bin/setup` / `rails db:prepare` nefunguje, pada s chybou pri zbiehani migracii, co ale tato PR neriesi:
```
== Preparing database ==
== 20181201110114 AddSomeStaticContent: migrating =============================
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:
undefined method `is_searchable?' for #<Page:0x0000557f05bf23e8>
Did you mean?  searchable?
```
* README som naklepal v anglictine, kedze bolo take hybridne, rad prelozim, ak je treba
