### PR TITLE
Support step action after submission

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -10,7 +10,7 @@ class SubmissionsController < ApplicationController
 
   def create
     if @submission.save
-      redirect_to submission_path(@submission)
+      redirect_to @submission
     else
       render :start, status: :unprocessable_entity
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -69,7 +69,6 @@ class SubmissionsController < ApplicationController
 
   def load_submission
     @submission = current_user.find_submission!(params[:id] || params[:submission_id])
-    @submission.current_user = current_user
   end
 
   def find_callback_step_by_path(callback_step_path)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -43,7 +43,7 @@ class SubmissionsController < ApplicationController
     params.require(:submission).permit(
       :email,
       :callback_url,
-      :callback_step_id,
+      :callback_step_path,
       :callback_step_status,
       :raw_extra,
       subscription_types: [],
@@ -69,5 +69,6 @@ class SubmissionsController < ApplicationController
 
   def load_submission
     @submission = current_user.find_submission!(params[:id] || params[:submission_id])
+    @submission.current_user = current_user
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -74,7 +74,7 @@ class SubmissionsController < ApplicationController
 
   def find_callback_step_by_path(callback_step_path)
     route = Rails.application.routes.recognize_path(callback_step_path)
-      return nil if route < { controller: 'steps', action: 'show' }
+    return nil if route < { controller: 'steps', action: 'show' }
 
     Step.where(slug: route[:id]).joins(:journey).where(journey: { slug: route[:journey_id] }).first
   end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -16,6 +16,7 @@ class AnonymousUser
     submission.skip_subscribe = skip_subscribe
     submission.current_user = self
     submission.callback_step = callback_step
+
     submission
   end
 

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -15,7 +15,7 @@ class AnonymousUser
     submission.extra = params[:raw_extra] ? JSON.parse(params[:raw_extra]) : extra
     submission.skip_subscribe = skip_subscribe
     submission.current_user = self
-    submission.callback_step = callback_step if callback_step
+    submission.callback_step = callback_step
     submission
   end
 

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -20,6 +20,8 @@ class AnonymousUser
   end
 
   def find_submission!(uuid)
-    Submission.where(anonymous_user_uuid: self.uuid, uuid: uuid).first!
+    submission = Submission.where(anonymous_user_uuid: self.uuid, uuid: uuid).first!
+    submission.current_user = self
+    submission
   end
 end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -9,12 +9,13 @@ class AnonymousUser
     false
   end
 
-  def build_submission(params, extra:, skip_subscribe: )
+  def build_submission(params, extra:, skip_subscribe:, callback_step:)
     submission = Submission.new(params)
     submission.anonymous_user_uuid = @uuid
     submission.extra = params[:raw_extra] ? JSON.parse(params[:raw_extra]) : extra
     submission.skip_subscribe = skip_subscribe
     submission.current_user = self
+    submission.callback_step = callback_step if callback_step
     submission
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -4,11 +4,11 @@ class Submission < ApplicationRecord
   attr_accessor :subscription_types, :raw_extra, :skip_subscribe, :current_user, :callback_step_path
 
   before_create { self.uuid = SecureRandom.uuid } # TODO ensure unique in loop
+  before_create { self.selected_subscription_types = [] if skip_subscribe }
   after_create :subscribe, unless: :skip_subscribe
 
   validates_presence_of :email, message: 'Zadajte emailovú adresu', unless: :skip_subscribe
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "Zadajte emailovú adresu v platnom tvare, napríklad jan.novak@firma.sk" }, unless: :skip_subscribe
-
   validates :selected_subscription_types, presence: { message: 'Vyberte si aspoň jednu možnosť' }, unless: :skip_subscribe
 
   scope :expired, -> { where('created_at < ?', 20.minutes.ago) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,4 +25,10 @@ class User < ApplicationRecord
   def find_submission!(uuid)
     submissions.find_by!(uuid: uuid)
   end
+
+  def update_step_status(step, status)
+    user_journey = UserJourney.order(id: :desc).find_by(user: self, journey: step.journey) || user_journeys.create!(journey: step.journey)
+    user_step = user_journey.user_steps.find_or_initialize_by(step: step)
+    user_step.update(status: status)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,9 @@ class User < ApplicationRecord
   end
 
   def find_submission!(uuid)
-    submissions.find_by!(uuid: uuid)
+    submission = submissions.find_by!(uuid: uuid)
+    submission.current_user = self
+    submission
   end
 
   def update_step_status(step, status)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
     submission.extra = params[:raw_extra] ? JSON.parse(params[:raw_extra]) : extra
     submission.skip_subscribe = skip_subscribe
     submission.current_user = self
-    submission.callback_step = callback_step if callback_step
+    submission.callback_step = callback_step
     submission
   end
 

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @submission, id: dom_id(@submission), html: { novalidate: true } do |f| %>
   <%= f.hidden_field :callback_url %>
-  <%= f.hidden_field :callback_step_id %>
+  <%= f.hidden_field :callback_step_path %>
   <%= f.hidden_field :callback_step_status %>
   <%= f.hidden_field :raw_extra %>
 

--- a/app/views/submissions/test.html.erb
+++ b/app/views/submissions/test.html.erb
@@ -25,7 +25,7 @@
         <input type="text" name="submission[email]" value="jan.suchal@slovensko.digital" id="email"/>
 
         <label for="callback_url">callback_url</label>
-        <input type="text" name="submission[callback_url]" value="/zivotne-situacie/odklad-danoveho-priznania/krok/prihlasit-sa-na-financnu-spravu" id="callback_url" />
+        <input type="text" name="submission[callback_url]" value="/zivotne-situacie/odklad-danoveho-priznania/krok/registrovat-sa-na-financnej-sprave" id="callback_url" />
 
         <label for="notif_subs">Notification subscription types: </label>
         <input type="text" name="submission[subscription_types][]" value="EmailMeSubmissionInstructionsEmail" id="notif_subs" />

--- a/app/views/submissions/test.html.erb
+++ b/app/views/submissions/test.html.erb
@@ -25,7 +25,7 @@
         <input type="text" name="submission[email]" value="jan.suchal@slovensko.digital" id="email"/>
 
         <label for="callback_url">callback_url</label>
-        <input type="text" name="submission[callback_url]" value="/zivotne-situacie/elektronicke-podanie-danoveho-priznania/krok/prihlasit-sa-na-financnu-spravu" id="callback_url" />
+        <input type="text" name="submission[callback_url]" value="/zivotne-situacie/odklad-danoveho-priznania/krok/prihlasit-sa-na-financnu-spravu" id="callback_url" />
 
         <label for="notif_subs">Notification subscription types: </label>
         <input type="text" name="submission[subscription_types][]" value="EmailMeSubmissionInstructionsEmail" id="notif_subs" />
@@ -62,6 +62,12 @@
 
         <label for="newsletter">submission[extra][params][newsletter]</label>
         <input type="text" name="submission[extra][params][newsletter]" value="false" id="newsletter" />
+
+        <label for="callback_step_url">callback_step_path</label>
+        <input type="text" name="submission[callback_step_path]" value="/zivotne-situacie/odklad-danoveho-priznania/krok/pripravit-danove-priznanie" id="callback_step_url" />
+
+        <label for="callback_step_action">callback_step_status</label>
+        <input type="text" name="submission[callback_step_status]" value="done" id="done" />
 
         <input type="submit" value="Podať" />
       </form>

--- a/db/migrate/20210321133303_add_callback_step_action_fields.rb
+++ b/db/migrate/20210321133303_add_callback_step_action_fields.rb
@@ -1,0 +1,7 @@
+class AddCallbackStepActionFields < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key :submissions, column: :callback_step_id
+    change_column :submissions, :callback_step_id, :string
+    rename_column :submissions, :callback_step_id, :callback_step_path
+  end
+end

--- a/db/migrate/20210321172132_fix_callback_step.rb
+++ b/db/migrate/20210321172132_fix_callback_step.rb
@@ -1,0 +1,7 @@
+class FixCallbackStep < ActiveRecord::Migration[6.1]
+  def change
+    change_column :submissions, :callback_step_path, 'bigint USING CAST(callback_step_path AS bigint)'
+    rename_column :submissions, :callback_step_path, :callback_step_id
+    add_foreign_key :submissions, :steps, column: :callback_step_id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20210321181737_fix_submission_fk_trigger.rb
+++ b/db/migrate/20210321181737_fix_submission_fk_trigger.rb
@@ -1,0 +1,6 @@
+class FixSubmissionFkTrigger < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key :submissions, :steps, column: :callback_step_id # remove cascade
+    add_foreign_key :submissions, :steps, column: :callback_step_id, on_delete: :nullify
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -594,7 +594,7 @@ CREATE TABLE public.submissions (
     anonymous_user_uuid uuid,
     email character varying,
     callback_url character varying NOT NULL,
-    callback_step_path character varying,
+    callback_step_id bigint,
     callback_step_status character varying,
     selected_subscription_types character varying[] DEFAULT '{}'::character varying[] NOT NULL,
     attachments jsonb,
@@ -1131,10 +1131,10 @@ CREATE UNIQUE INDEX index_submissions_on_anonymous_user_uuid_and_uuid ON public.
 
 
 --
--- Name: index_submissions_on_callback_step_path; Type: INDEX; Schema: public; Owner: -
+-- Name: index_submissions_on_callback_step_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_submissions_on_callback_step_path ON public.submissions USING btree (callback_step_path);
+CREATE INDEX index_submissions_on_callback_step_id ON public.submissions USING btree (callback_step_id);
 
 
 --
@@ -1327,6 +1327,14 @@ ALTER TABLE ONLY public.user_journeys
 
 
 --
+-- Name: submissions fk_rails_8999639afc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.submissions
+    ADD CONSTRAINT fk_rails_8999639afc FOREIGN KEY (callback_step_id) REFERENCES public.steps(id) ON DELETE CASCADE;
+
+
+--
 -- Name: quick_tips fk_rails_8c50350cb1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1418,6 +1426,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200316104715'),
 ('20200919092214'),
 ('20210318070336'),
-('20210321133303');
+('20210321133303'),
+('20210321172132');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -594,7 +594,7 @@ CREATE TABLE public.submissions (
     anonymous_user_uuid uuid,
     email character varying,
     callback_url character varying NOT NULL,
-    callback_step_id bigint,
+    callback_step_path character varying,
     callback_step_status character varying,
     selected_subscription_types character varying[] DEFAULT '{}'::character varying[] NOT NULL,
     attachments jsonb,
@@ -1131,10 +1131,10 @@ CREATE UNIQUE INDEX index_submissions_on_anonymous_user_uuid_and_uuid ON public.
 
 
 --
--- Name: index_submissions_on_callback_step_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_submissions_on_callback_step_path; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_submissions_on_callback_step_id ON public.submissions USING btree (callback_step_id);
+CREATE INDEX index_submissions_on_callback_step_path ON public.submissions USING btree (callback_step_path);
 
 
 --
@@ -1327,14 +1327,6 @@ ALTER TABLE ONLY public.user_journeys
 
 
 --
--- Name: submissions fk_rails_8999639afc; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.submissions
-    ADD CONSTRAINT fk_rails_8999639afc FOREIGN KEY (callback_step_id) REFERENCES public.steps(id);
-
-
---
 -- Name: quick_tips fk_rails_8c50350cb1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1425,6 +1417,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200316102804'),
 ('20200316104715'),
 ('20200919092214'),
-('20210318070336');
+('20210318070336'),
+('20210321133303');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1331,7 +1331,7 @@ ALTER TABLE ONLY public.user_journeys
 --
 
 ALTER TABLE ONLY public.submissions
-    ADD CONSTRAINT fk_rails_8999639afc FOREIGN KEY (callback_step_id) REFERENCES public.steps(id) ON DELETE CASCADE;
+    ADD CONSTRAINT fk_rails_8999639afc FOREIGN KEY (callback_step_id) REFERENCES public.steps(id) ON DELETE SET NULL;
 
 
 --
@@ -1427,6 +1427,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200919092214'),
 ('20210318070336'),
 ('20210321133303'),
-('20210321172132');
+('20210321172132'),
+('20210321181737');
 
 

--- a/spec/features/submissions_spec.rb
+++ b/spec/features/submissions_spec.rb
@@ -99,6 +99,7 @@ RSpec.feature "Submissions feature", type: :feature do
 
     click_button 'Súbory chcem len stiahnuť'
 
+    expect(page).to have_content('Všetky tieto súbory si stiahnite na bezpečné miesto.')
     expect(page).to have_content('odklad-danoveho-priznania.xml')
 
     click_link 'Stiahnuť súbor'
@@ -120,6 +121,7 @@ RSpec.feature "Submissions feature", type: :feature do
 
     click_button 'Súbory chcem len stiahnuť'
 
+    expect(page).to have_content('Všetky tieto súbory si stiahnite na bezpečné miesto.')
     expect(page).to have_content('odklad-danoveho-priznania.xml')
 
     click_link 'Stiahnuť súbor'


### PR DESCRIPTION
Toto pridava podporu pre callback action na urovni kroku po podani. Cize vieme napriklad potom ako clovek nieco poda a je prihlaseny, mu oznacit nejaky krok ako hotovy-pending-waiting. 

parametre su `callback_step_path` a `callback_step_status` pricom path je cesta ku kroku a status moze byt toto https://github.com/slovensko-digital/navody.digital/blob/master/app/models/user_step.rb#L9

Cize na nejakych testovacich datach to po odoslani submission a pokracovani dalej vyzera rovno takto:

![image](https://user-images.githubusercontent.com/26342/111908456-a03ce580-8a59-11eb-9e8a-aee9406ffe1e.png)
