### PR TITLE
Fix page og image - remove "journeys/"

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,6 +11,6 @@ class PagesController < ApplicationController
   def show
     @page = Page.find_by_slug!(params[:id])
 
-    @metadata.og.image = "journeys/#{@page.image_name.presence || "placeholder.png" }"
+    @metadata.og.image = @page.image_name.presence || "placeholder.png"
   end
 end


### PR DESCRIPTION
@jsuchal toto je taký hotfix pre kritický problém pre komunikáciu, že pri pages tam z nejakého dôvodu bol takýto prefix a teda to robilo `journeys/#https://s3.amazon...`. Pri zvyšných dokumentoch to je takto bez toho prefixu.