### PR TITLE
ND-159 Make code list queries case insensitive, Update checking stakeholder identifiers condition

### DIFF
--- a/app/lib/or_sr_record_fetcher.rb
+++ b/app/lib/or_sr_record_fetcher.rb
@@ -46,10 +46,10 @@ class OrSrRecordFetcher
     stakeholders_table.css('td[align=left]').last.children.each do |stakeholder_table|
       stakeholder_name = get_stakeholder_name(stakeholder_table)
 
-      if stakeholder_table.css('a>img').first['alt'].start_with?("Osoba nemá")
-        missing << stakeholder_name
-      else
+      if stakeholder_status_ok?(stakeholder_table)
         ok << stakeholder_name
+      else
+        missing << stakeholder_name
       end
     end
 
@@ -137,5 +137,13 @@ class OrSrRecordFetcher
     else
       stakeholder_table.css('td').first.css('span').first.inner_text.strip
     end
+  end
+
+  def self.stakeholder_status_ok?(stakeholder_table)
+    stakeholder_table.css('a>img').each do |a|
+      return false if a['alt'].start_with?("Osoba nemá")
+    end
+
+    true
   end
 end

--- a/app/lib/upvs_submissions/forms/fuzs_data.rb
+++ b/app/lib/upvs_submissions/forms/fuzs_data.rb
@@ -92,11 +92,11 @@ module UpvsSubmissions
         end
 
         def municipality_code_list
-          original_municipality_similars = CodeList::Municipality.where("value like ?", "#{@original_municipality}%")
+          original_municipality_similars = CodeList::Municipality.where("value ilike ?", "#{@original_municipality}%")
 
           return original_municipality_similars if original_municipality_similars.present?
 
-          CodeList::Municipality.where("value like ?", "#{@original_municipality.split('-')&.first&.strip}%")
+          CodeList::Municipality.where("value ilike ?", "#{@original_municipality.split('-')&.first&.strip}%")
         end
 
         def unsupported_slovak_address?
@@ -120,12 +120,12 @@ module UpvsSubmissions
         def load_municipality_identifier
           return unless slovak?
 
-          municipality_code_list_object = CodeList::Municipality.where(value: @municipality&.strip).take
+          municipality_code_list_object = CodeList::Municipality.where("lower(value) = ?", @municipality&.strip.downcase).take
           @municipality_identifier = municipality_code_list_object&.identifier
         end
 
         def load_country_identifier
-          country_code_list_object = CodeList::Country.where(value: @country&.strip).take
+          country_code_list_object = CodeList::Country.where("lower(value) = ?", @country&.strip.downcase).take
           @country_identifier = country_code_list_object&.identifier
         end
 


### PR DESCRIPTION
Zistila som, ze na ORSR webe pribudla pri spolocnikoch ikonka navyse, co nam rozbilo vyhodnocovanie, ci su identifikatory OK. Aktualne vyhodnocuje vsetkych OK.
Este som nasla, ze obcas je napr. _Bratislava - mestská časť Staré **M**esto_ napisana ako _Bratislava - mestská časť Staré **m**esto_, a vtedy vyzadujeme uvedenie adresy od pouzivatela (zbytocne). Tak som rovno aj to fixla.