### PR TITLE
Enhance submissions cleanup process

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -60,7 +60,7 @@ class SubmissionsController < ApplicationController
 
   def build_submission
     @submission = current_user.build_submission(
-      submission_params.merge(expires_at: params[:skip_subscribe] ? Submission.expiration_time : nil),
+      submission_params,
       extra: params[:submission][:extra],
       skip_subscribe: params[:skip_subscribe],
       callback_step: find_callback_step_by_path(submission_params[:callback_step_path])

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -60,7 +60,7 @@ class SubmissionsController < ApplicationController
 
   def build_submission
     @submission = current_user.build_submission(
-      submission_params,
+      submission_params.merge(expires_at: params[:skip_subscribe] ? Submission.expiration_time : nil),
       extra: params[:submission][:extra],
       skip_subscribe: params[:skip_subscribe],
       callback_step: find_callback_step_by_path(submission_params[:callback_step_path])

--- a/app/jobs/email_me_submission_instructions_email_job.rb
+++ b/app/jobs/email_me_submission_instructions_email_job.rb
@@ -4,7 +4,7 @@ class EmailMeSubmissionInstructionsEmailJob < ApplicationJob
   def perform(submission)
     email = build_template_email(submission)
     Submission.transaction do
-      submission.expires_at = submission.compute_expiration_time
+      submission.set_new_expiration_time
       submission.save!
       EmailService.send_email(email)
     end

--- a/app/jobs/email_me_submission_instructions_email_job.rb
+++ b/app/jobs/email_me_submission_instructions_email_job.rb
@@ -4,7 +4,7 @@ class EmailMeSubmissionInstructionsEmailJob < ApplicationJob
   def perform(submission)
     email = build_template_email(submission)
     Submission.transaction do
-      submission.expires_at = Submission.expiration_time
+      submission.expires_at = submission.compute_expiration_time
       submission.save!
       EmailService.send_email(email)
     end

--- a/app/jobs/email_me_submission_instructions_email_job.rb
+++ b/app/jobs/email_me_submission_instructions_email_job.rb
@@ -3,7 +3,11 @@ class EmailMeSubmissionInstructionsEmailJob < ApplicationJob
 
   def perform(submission)
     email = build_template_email(submission)
-    EmailService.send_email(email)
+    Submission.transaction do
+      submission.expires_at = Submission.expiration_time
+      submission.save!
+      EmailService.send_email(email)
+    end
   end
 
   private

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,6 +5,7 @@ class Submission < ApplicationRecord
 
   before_create { self.uuid = SecureRandom.uuid } # TODO ensure unique in loop
   before_create { self.selected_subscription_types = [] if skip_subscribe }
+  before_create { self.expires_at = skip_subscribe ? compute_expiration_time : nil }
   after_create :subscribe, unless: :skip_subscribe
 
   validates_presence_of :email, message: 'Zadajte emailovú adresu', unless: :skip_subscribe
@@ -13,7 +14,7 @@ class Submission < ApplicationRecord
 
   scope :expired, -> { where('expires_at < ?', Time.zone.now) }
 
-  def self.expiration_time
+  def compute_expiration_time
     Time.zone.now + 20.minutes
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,7 +5,7 @@ class Submission < ApplicationRecord
 
   before_create { self.uuid = SecureRandom.uuid } # TODO ensure unique in loop
   before_create { self.selected_subscription_types = [] if skip_subscribe }
-  before_create { set_new_expiration_time unless skip_subscribe }
+  before_create { set_new_expiration_time if skip_subscribe }
   after_create :subscribe, unless: :skip_subscribe
 
   validates_presence_of :email, message: 'Zadajte emailovú adresu', unless: :skip_subscribe

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -11,7 +11,11 @@ class Submission < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "Zadajte emailovú adresu v platnom tvare, napríklad jan.novak@firma.sk" }, if: -> { email.present? }, unless: :skip_subscribe
   validates :selected_subscription_types, presence: { message: 'Vyberte si aspoň jednu možnosť' }, unless: :skip_subscribe
 
-  scope :expired, -> { where('created_at < ?', 20.minutes.ago) }
+  scope :expired, -> { where('expires_at < ?', Time.zone.now) }
+
+  def self.expiration_time
+    Time.zone.now + 20.minutes
+  end
 
   def subscribe
     selected_subscription_objects.filter_map { |s| s[:on_submission_job] }.each { |job| job.perform_later(self) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,7 +5,7 @@ class Submission < ApplicationRecord
 
   before_create { self.uuid = SecureRandom.uuid } # TODO ensure unique in loop
   before_create { self.selected_subscription_types = [] if skip_subscribe }
-  before_create { self.expires_at = skip_subscribe ? compute_expiration_time : nil }
+  before_create { set_new_expiration_time unless skip_subscribe }
   after_create :subscribe, unless: :skip_subscribe
 
   validates_presence_of :email, message: 'Zadajte emailovú adresu', unless: :skip_subscribe
@@ -14,8 +14,8 @@ class Submission < ApplicationRecord
 
   scope :expired, -> { where('expires_at < ?', Time.zone.now) }
 
-  def compute_expiration_time
-    Time.zone.now + 20.minutes
+  def set_new_expiration_time
+    self.expires_at = Time.zone.now + 20.minutes
   end
 
   def subscribe

--- a/db/migrate/20230325151049_add_expires_at_to_submission.rb
+++ b/db/migrate/20230325151049_add_expires_at_to_submission.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToSubmission < ActiveRecord::Migration[6.1]
+  def change
+    add_column :submissions, :expires_at, :timestamp
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -965,7 +965,8 @@ CREATE TABLE public.submissions (
     attachments jsonb,
     extra jsonb,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    expires_at timestamp without time zone
 );
 
 
@@ -2137,6 +2138,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220914073653'),
 ('20220921082415'),
 ('20221022143119'),
-('20230325092744');
+('20230325092744'),
+('20230325151049');
 
 


### PR DESCRIPTION
Submissions which are to be sent via email are destroyed only once the email has been sent. Other submissions are still removed after 20 minutes as usual.

This prevents any issues/delays of email delivery worker to cause loss of submission data before the job gets to the actual processing.