### PR TITLE
make /usr/bin/mkdir available for installing gems into the vscode image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,6 +25,7 @@ RUN curl -sSL https://get.rvm.io | bash -s
 RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && rvm install 3.2.1"
 
 # Install Rails
+RUN ln -s /bin/mkdir /usr/bin/mkdir
 RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && gem install rails webdrivers"
 RUN chown -R vscode /usr/local/rvm
 


### PR DESCRIPTION
Without this the rails/webdrivers installation into mcr.microsoft.com/vscode/devcontainers/base:bullseye fails with:

make DESTDIR\= sitearchdir\=./.gem.20230627-76-qe4u9x sitelibdir\=./.gem.20230627-76-qe4u9x install make: /usr/bin/mkdir: No such file or directory