### PR TITLE
Disable active topic in president vote app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,10 @@ class ApplicationController < ActionController::Base
     @disable_feedback = true
   end
 
+  def disable_current_topic
+    @active_current_topic = nil
+  end
+
   private
 
   def set_default_metadata

--- a/app/controllers/apps/president_vote_app/application_forms_controller.rb
+++ b/app/controllers/apps/president_vote_app/application_forms_controller.rb
@@ -1,6 +1,6 @@
 class Apps::PresidentVoteApp::ApplicationFormsController < ApplicationController
   helper FormatDaysHelper
-  before_action :set_metadata, :check_inactive_president_application
+  before_action :set_metadata, :check_inactive_president_application, :disable_current_topic
   before_action :disable_feedback, only: [:show, :delivery, :create]
 
   def show


### PR DESCRIPTION
Keď už niekto príde do volebnej appky, nemá zmysel, aby hore ešte zaberal miesto banner s upozornením, že máme appku pre voľby. A to, že človek príde externe cez nejaký post rovno do appky je najčastejší prípad. Preto by som všeobecne vypol current topic v appke.