### PR TITLE
Build categorization explicitly when editing a journey

### DIFF
--- a/app/controllers/admin/journeys_controller.rb
+++ b/app/controllers/admin/journeys_controller.rb
@@ -19,6 +19,7 @@ class Admin::JourneysController < Admin::AdminController
 
   # GET /admin/journeys/1/edit
   def edit
+    @journey.build_categorization unless @journey.categorization
   end
 
   # POST /admin/journeys


### PR DESCRIPTION
Without this, category ids section is missing in journey edit form, making it impossible to assign existing journeys to categories.

closes #693